### PR TITLE
Improvements for Proposal Create mock

### DIFF
--- a/teste2e/cypress/e2e/proposal/create.js
+++ b/teste2e/cypress/e2e/proposal/create.js
@@ -4,6 +4,16 @@ import {
   PROPOSAL_SUMMARY_STATUS_UNVETTED
 } from "../../utils";
 
+beforeEach(function mockApiCalls() {
+  // currently mocking pi and ticketvote summaries calls with any status, since
+  // they aren't used for assertions.
+  cy.useTicketvoteApi();
+  cy.useRecordsApi();
+  cy.usePiApi();
+  cy.useWwwApi();
+  cy.useCommentsApi();
+});
+
 describe("Proposal Create", () => {
   // XXX This test needs changes in the Datepicker and (probably) the Select
   // components, in order to fill the new form fields such as: start & end dates
@@ -11,27 +21,15 @@ describe("Proposal Create", () => {
   //
   it("Paid user can create proposals manually", () => {
     // paid user with proposal credits
-    const user = {
-      email: "adminuser@example.com",
-      username: "adminuser",
-      password: "password"
-    };
+    cy.userEnvironment("user", { verifyIdentity: true });
     const proposal = buildProposal();
-    cy.login(user);
-    cy.visit("/");
-    cy.identity();
     cy.recordsMiddleware("new", {});
     cy.visit("/record/new");
     cy.typeCreateProposal(proposal);
   });
 
   it("Non-paid user can not create proposals", () => {
-    const user = {
-      email: "user3@example.com",
-      username: "user3",
-      password: "password"
-    };
-    cy.login(user);
+    cy.userEnvironment("unpaid", { verifyIdentity: true });
     cy.visit("/");
     cy.findByText(/new proposal/i).should("be.disabled");
     cy.visit("/record/new");

--- a/teste2e/cypress/pki.js
+++ b/teste2e/cypress/pki.js
@@ -70,7 +70,7 @@ export const keysToHex = ({ publicKey, secretKey }) => ({
   secretKey: toHex(secretKey)
 });
 
-const keysFromHex = ({ publicKey, secretKey }) => ({
+export const keysFromHex = ({ publicKey, secretKey }) => ({
   publicKey: toByteArray(publicKey),
   secretKey: toByteArray(secretKey)
 });

--- a/teste2e/cypress/support/users/api.js
+++ b/teste2e/cypress/support/users/api.js
@@ -1,6 +1,6 @@
 import pick from "lodash/fp/pick";
 
-import { PaymentCredits, User, userByType } from "./generate";
+import { PaymentCredits, User, userByType, Identity } from "./generate";
 
 export const API_BASE_URL = "/api/v1/user";
 
@@ -11,10 +11,15 @@ export const API_BASE_URL = "/api/v1/user";
  * @returns User
  */
 export function loginReply({
-  testParams: { userType, ...userProps },
+  testParams: { userType, verifyIdentity, ...userProps },
   requestParams: { email }
 }) {
-  return userByType(userType, { ...userProps, email });
+  const user = userByType(userType, { ...userProps, email });
+  if (verifyIdentity) {
+    const { userid, publickey } = user;
+    Identity({ userid, publickey });
+  }
+  return user;
 }
 
 /**
@@ -23,8 +28,13 @@ export function loginReply({
  * @param {Object} { testParams }
  * @returns User
  */
-export function meReply({ testParams: { userType } }) {
-  return userByType(userType);
+export function meReply({ testParams: { userType, verifyIdentity } }) {
+  const user = userByType(userType);
+  if (verifyIdentity) {
+    const { userid, publickey } = user;
+    Identity({ userid, publickey });
+  }
+  return user;
 }
 
 /**

--- a/teste2e/cypress/support/users/commands.js
+++ b/teste2e/cypress/support/users/commands.js
@@ -8,13 +8,13 @@ Cypress.Commands.add(
   createMiddleware({ packageName: "user", repliers, baseUrl: API_BASE_URL })
 );
 
-Cypress.Commands.add("userEnvironment", (userType) => {
+Cypress.Commands.add("userEnvironment", (userType, { verifyIdentity } = {}) => {
   cy.wwwMiddleware(
     "api",
     { isActive: userType !== "noLogin" },
     { headers: { "x-csrf-token": "abcdefghijklmnopqrstuvwxyz" } }
   );
-  cy.userMiddleware("me", { userType });
+  cy.userMiddleware("me", { userType, verifyIdentity });
   cy.userMiddleware("payments/registration", {
     haspaid: userType !== "unpaid"
   });

--- a/teste2e/cypress/support/users/generate.js
+++ b/teste2e/cypress/support/users/generate.js
@@ -2,6 +2,7 @@ import faker from "faker";
 import compose from "lodash/fp/compose";
 import map from "lodash/fp/map";
 import times from "lodash/fp/times";
+import * as pki from "../../pki";
 
 export function User({
   isadmin = false,
@@ -22,7 +23,7 @@ export function User({
   this.paywalladdress = paywalladdress || `Ts${faker.datatype.hexaDecimal(33)}`;
   this.paywalltxid =
     paywalltxid || faker.datatype.hexaDecimal(64, false, /[0-9a-z]/);
-  this.publickey = publickey || faker.datatype.hexaDecimal(64);
+  this.publickey = publickey || pki.toHex(faker.datatype.hexaDecimal(64));
   this.paywallamount = 10000000;
   this.paywalltxnotbefore = Date.now() / 1000 - 3600;
   this.lastlogintime = faker.time.recent() / 1000;
@@ -60,13 +61,13 @@ export function userByType(userType, props) {
     case "unpaid":
       return UserUnpaid(props);
     case "user":
-      return User(props);
+      return new User(props);
     case "totp":
       return UserTotp(props);
     case "noLogin":
       return {};
     default:
-      return User(props);
+      return new User(props);
   }
 }
 
@@ -82,4 +83,14 @@ export function PaymentCredits({ spent = 0, unspent = 0 } = {}) {
   );
   this.spentcredits = makeCredits(spent);
   this.unspentcredits = makeCredits(unspent);
+}
+
+export function Identity({ userid, publickey }) {
+  return pki.generateKeys().then((keys) => {
+    const stringKeys = {
+      secretKey: pki.toHex(keys.secretKey),
+      publicKey: publickey
+    };
+    pki.importKeys(userid, stringKeys);
+  });
 }


### PR DESCRIPTION
This commit adds the `verifyIdentity` option to user login and me
requests, and improves the proposal create tests to avoid reaching any
backend endpoints.